### PR TITLE
Send text

### DIFF
--- a/aiomessenger/client.py
+++ b/aiomessenger/client.py
@@ -8,6 +8,19 @@ GRAPH_URL = 'https://graph.facebook.com'
 GRAPH_API_VERSION = '3.2'
 
 
+_ALLOWED_NOTIFICATION_TYPE = [
+    'REGULAR',
+    'SILENT_PUSH',
+    'NO_PUSH',
+]
+
+_ALLOWED_MESSAGING_TYPE = [
+    'RESPONSE',
+    'UPDATE',
+    'MESSAGE_TAG',
+]
+
+
 class Client:
 
     # TODO: list all members here
@@ -81,22 +94,32 @@ class Client:
 
     async def send_raw_data(
             self,
-            psid: str,
-            message: Mapping[str, str],
             messaging_type: str,
+            recipient: Mapping[str, str],
+            message: Mapping[str, str],
+            notification_type: str = 'REGULAR',
+            attachment: str = None,
+            tag: str = None,
             persona_id: str = None,
         ):
-        # TODO: validate messaging to have correct value
         # ref: https://developers.facebook.com/docs/messenger-platform/send-messages/#messaging_types  # noqa
+        assert messaging_type in _ALLOWED_MESSAGING_TYPE
+        assert notification_type in _ALLOWED_NOTIFICATION_TYPE
+
         post_data = {
             "messaging_type": messaging_type,
-            "recipient": {
-                "id": psid,
-            },
+            "recipient": recipient,
             'message': message,
+            'notification_type': notification_type,
         }
+
+        if attachment is not None:
+            post_data['attachment'] = attachment
         if persona_id is not None:
             post_data['persona_id'] = persona_id
+        if tag is not None:
+            post_data['tag'] = tag
+
         resp = await self.post('/me/messages', data=post_data)
         return resp
 

--- a/aiomessenger/client.py
+++ b/aiomessenger/client.py
@@ -92,7 +92,7 @@ class Client:
         async with self._session.post(target_url, params=params, json=data) as resp:
             return await resp.json()
 
-    async def send_raw_data(
+    async def send_message(
             self,
             messaging_type: str,
             recipient: Mapping[str, str],

--- a/aiomessenger/client.py
+++ b/aiomessenger/client.py
@@ -1,5 +1,5 @@
 import asyncio as aio
-from typing import Optional, Mapping
+from typing import Optional, Mapping, Union
 
 from aiohttp import ClientSession
 
@@ -95,7 +95,7 @@ class Client:
     async def send_message(
             self,
             messaging_type: str,
-            recipient: Mapping[str, str],
+            recipient: Union[str, Mapping[str, str]],
             message: Mapping[str, str],
             notification_type: str = 'REGULAR',
             attachment: str = None,
@@ -106,6 +106,8 @@ class Client:
         assert messaging_type in _ALLOWED_MESSAGING_TYPE
         assert notification_type in _ALLOWED_NOTIFICATION_TYPE
 
+        if isinstance(recipient, str):
+            recipient = {'id': recipient}
         post_data = {
             "messaging_type": messaging_type,
             "recipient": recipient,
@@ -121,6 +123,26 @@ class Client:
             post_data['tag'] = tag
 
         resp = await self.post('/me/messages', data=post_data)
+        return resp
+
+    async def send_text(
+            self,
+            recipient: Union[str, Mapping[str, str]],
+            text: str,
+            messaging_type: str = 'UPDATE',
+            notification_type: str = 'REGULAR',
+            tag: str = None,
+            persona_id: str = None,
+        ):
+        message = {'text': text}
+        resp = await self.send_message(
+            recipient=recipient,
+            message=message,
+            messaging_type=messaging_type,
+            notification_type=notification_type,
+            tag=tag,
+            persona_id=persona_id,
+        )
         return resp
 
     async def debug_token(self):

--- a/aiomessenger/client.py
+++ b/aiomessenger/client.py
@@ -98,7 +98,6 @@ class Client:
             recipient: Union[str, Mapping[str, str]],
             message: Mapping[str, str],
             notification_type: str = 'REGULAR',
-            attachment: str = None,
             tag: str = None,
             persona_id: str = None,
         ):
@@ -115,8 +114,6 @@ class Client:
             'notification_type': notification_type,
         }
 
-        if attachment is not None:
-            post_data['attachment'] = attachment
         if persona_id is not None:
             post_data['persona_id'] = persona_id
         if tag is not None:

--- a/aiomessenger/tests/test_client.py
+++ b/aiomessenger/tests/test_client.py
@@ -142,14 +142,14 @@ async def test_post_with_param_and_data(client):
 
 
 @pytest.mark.asyncio
-async def test_send_raw_data(client):
+async def test_send_message(client):
     client.post = CoroutineMock()
     messaging_type = 'UPDATE'
     recipient = {'id': '12uyg34iu12y34'}
     message = {'text': 'hello'}
     notification_type = 'SILENT_PUSH'
     persona_id = 'asdf'
-    await client.send_raw_data(
+    await client.send_message(
         messaging_type,
         recipient,
         message,
@@ -169,14 +169,14 @@ async def test_send_raw_data(client):
 
 
 @pytest.mark.asyncio
-async def test_send_raw_data_with_persona_id(client):
+async def test_send_message_with_persona_id(client):
     client.post = CoroutineMock()
     messaging_type = 'UPDATE'
     recipient = {'id': '12uyg34iu12y34'}
     message = {'text': 'hello'}
     notification_type = 'SILENT_PUSH'
     persona_id = 'asdf'
-    await client.send_raw_data(
+    await client.send_message(
         messaging_type,
         recipient,
         message,
@@ -196,14 +196,14 @@ async def test_send_raw_data_with_persona_id(client):
 
 
 @pytest.mark.asyncio
-async def test_send_raw_data_with_tag(client):
+async def test_send_message_with_tag(client):
     client.post = CoroutineMock()
     messaging_type = 'UPDATE'
     recipient = {'id': '12uyg34iu12y34'}
     message = {'text': 'hello'}
     notification_type = 'SILENT_PUSH'
     tag = 'SHIPPING_UPDATE'
-    await client.send_raw_data(
+    await client.send_message(
         messaging_type,
         recipient,
         message,

--- a/aiomessenger/tests/test_client.py
+++ b/aiomessenger/tests/test_client.py
@@ -169,6 +169,33 @@ async def test_send_message(client):
 
 
 @pytest.mark.asyncio
+async def test_send_message_with_psid(client):
+    client.post = CoroutineMock()
+    messaging_type = 'UPDATE'
+    recipient = '12uyg34iu12y34'
+    message = {'text': 'hello'}
+    notification_type = 'SILENT_PUSH'
+    persona_id = 'asdf'
+    await client.send_message(
+        messaging_type,
+        recipient,
+        message,
+        notification_type,
+        persona_id=persona_id,
+    )
+    client.post.assert_called_once_with(
+        '/me/messages',
+        data={
+            "messaging_type": messaging_type,
+            "recipient": {'id': recipient},
+            'message': message,
+            'notification_type': notification_type,
+            'persona_id': persona_id,
+        },
+    )
+
+
+@pytest.mark.asyncio
 async def test_send_message_with_persona_id(client):
     client.post = CoroutineMock()
     messaging_type = 'UPDATE'
@@ -219,6 +246,33 @@ async def test_send_message_with_tag(client):
             'notification_type': notification_type,
             'tag': tag,
         },
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_text(client):
+    client.send_message = CoroutineMock()
+    messaging_type = 'UPDATE'
+    recipient = '12uyg34iu12y34'
+    text = 'hello'
+    notification_type = 'SILENT_PUSH'
+    tag = 'SHIPPING_UPDATE'
+    persona_id = 'asdf'
+    await client.send_text(
+        recipient=recipient,
+        text=text,
+        messaging_type=messaging_type,
+        notification_type=notification_type,
+        tag=tag,
+        persona_id=persona_id,
+    )
+    client.send_message.assert_called_once_with(
+        recipient=recipient,
+        message={'text': text},
+        messaging_type=messaging_type,
+        notification_type=notification_type,
+        tag=tag,
+        persona_id=persona_id,
     )
 
 

--- a/aiomessenger/tests/test_client.py
+++ b/aiomessenger/tests/test_client.py
@@ -144,18 +144,26 @@ async def test_post_with_param_and_data(client):
 @pytest.mark.asyncio
 async def test_send_raw_data(client):
     client.post = CoroutineMock()
-    psid = '12uyg34iu12y34'
-    message = {'text': 'hello'}
     messaging_type = 'UPDATE'
-    await client.send_raw_data(psid, message, messaging_type)
+    recipient = {'id': '12uyg34iu12y34'}
+    message = {'text': 'hello'}
+    notification_type = 'SILENT_PUSH'
+    persona_id = 'asdf'
+    await client.send_raw_data(
+        messaging_type,
+        recipient,
+        message,
+        notification_type,
+        persona_id=persona_id,
+    )
     client.post.assert_called_once_with(
         '/me/messages',
         data={
             "messaging_type": messaging_type,
-            "recipient": {
-                "id": psid,
-            },
+            "recipient": recipient,
             'message': message,
+            'notification_type': notification_type,
+            'persona_id': persona_id,
         },
     )
 
@@ -163,20 +171,53 @@ async def test_send_raw_data(client):
 @pytest.mark.asyncio
 async def test_send_raw_data_with_persona_id(client):
     client.post = CoroutineMock()
-    psid = '12uyg34iu12y34'
-    message = {'text': 'hello'}
     messaging_type = 'UPDATE'
+    recipient = {'id': '12uyg34iu12y34'}
+    message = {'text': 'hello'}
+    notification_type = 'SILENT_PUSH'
     persona_id = 'asdf'
-    await client.send_raw_data(psid, message, messaging_type, persona_id)
+    await client.send_raw_data(
+        messaging_type,
+        recipient,
+        message,
+        notification_type,
+        persona_id=persona_id,
+    )
     client.post.assert_called_once_with(
         '/me/messages',
         data={
             "messaging_type": messaging_type,
-            "recipient": {
-                "id": psid,
-            },
+            "recipient": recipient,
             'message': message,
+            'notification_type': notification_type,
             'persona_id': persona_id,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_raw_data_with_tag(client):
+    client.post = CoroutineMock()
+    messaging_type = 'UPDATE'
+    recipient = {'id': '12uyg34iu12y34'}
+    message = {'text': 'hello'}
+    notification_type = 'SILENT_PUSH'
+    tag = 'SHIPPING_UPDATE'
+    await client.send_raw_data(
+        messaging_type,
+        recipient,
+        message,
+        notification_type,
+        tag=tag,
+    )
+    client.post.assert_called_once_with(
+        '/me/messages',
+        data={
+            "messaging_type": messaging_type,
+            "recipient": recipient,
+            'message': message,
+            'notification_type': notification_type,
+            'tag': tag,
         },
     )
 


### PR DESCRIPTION
- Rename `send_raw_data` to `send_message` and make it a base function of all [Send API](https://developers.facebook.com/docs/messenger-platform/reference/send-api#recipient)

- Implement `send_text`:
```python
client = ...
client.send_text(
    recipient='PSID',
    text='Hello world',
)
```